### PR TITLE
Transcoding improvements: subtitles, in-place output, and error logging  

### DIFF
--- a/squishy/blueprints/admin.py
+++ b/squishy/blueprints/admin.py
@@ -188,10 +188,13 @@ def add_preset():
             "scale": scale,
             "container": container,
             "audio_codec": audio_codec,
-            "audio_bitrate": audio_bitrate,
             "force_software": force_software,
             "allow_fallback": allow_fallback,
         }
+
+        # Only include audio_bitrate when applicable
+        if audio_codec != "copy":
+            preset["audio_bitrate"] = audio_bitrate
 
         if subtitle_mode:
             preset["subtitle_mode"] = subtitle_mode
@@ -262,10 +265,13 @@ def edit_preset(name):
             "scale": scale,
             "container": container,
             "audio_codec": audio_codec,
-            "audio_bitrate": audio_bitrate,
             "force_software": force_software,
             "allow_fallback": allow_fallback,
         }
+
+        # Only include audio_bitrate when applicable
+        if audio_codec != "copy":
+            preset["audio_bitrate"] = audio_bitrate
 
         if subtitle_mode:
             preset["subtitle_mode"] = subtitle_mode

--- a/squishy/blueprints/admin.py
+++ b/squishy/blueprints/admin.py
@@ -179,6 +179,9 @@ def add_preset():
         force_software = request.form.get("force_software") == "on"
         allow_fallback = request.form.get("allow_fallback") == "on"
 
+        # Subtitle settings
+        subtitle_mode = "keep" if request.form.get("keep_subtitles") == "on" else None
+
         # Create the preset dictionary
         preset = {
             "codec": codec,
@@ -189,6 +192,9 @@ def add_preset():
             "force_software": force_software,
             "allow_fallback": allow_fallback,
         }
+
+        if subtitle_mode:
+            preset["subtitle_mode"] = subtitle_mode
 
         # Add either CRF or bitrate
         if use_crf and crf is not None:
@@ -247,6 +253,9 @@ def edit_preset(name):
         force_software = request.form.get("force_software") == "on"
         allow_fallback = request.form.get("allow_fallback") == "on"
 
+        # Subtitle settings
+        subtitle_mode = "keep" if request.form.get("keep_subtitles") == "on" else None
+
         # Update the preset
         preset = {
             "codec": codec,
@@ -257,6 +266,9 @@ def edit_preset(name):
             "force_software": force_software,
             "allow_fallback": allow_fallback,
         }
+
+        if subtitle_mode:
+            preset["subtitle_mode"] = subtitle_mode
 
         # Add either CRF or bitrate
         if use_crf and crf is not None:

--- a/squishy/blueprints/api.py
+++ b/squishy/blueprints/api.py
@@ -1,5 +1,6 @@
 """API blueprint for Squishy."""
 
+import os
 import traceback
 
 from flask import Blueprint, jsonify, request
@@ -143,6 +144,7 @@ def transcode():
 
     media_id = data["media_id"]
     preset_name = data["preset"]
+    output_mode = data.get("output_mode", "default")
 
     media_item = get_media(media_id)
     if media_item is None:
@@ -152,15 +154,19 @@ def transcode():
     if preset_name not in config.presets:
         return jsonify({"error": "Invalid preset"}), 400
 
-    job = create_job(media_item, preset_name)
+    if output_mode == "in_place":
+        output_dir = os.path.dirname(media_item.path)
+    else:
+        output_dir = config.transcode_path
 
-    # Use the transcode_path from the config object directly
-    # instead of relying on Flask's app.config
+    job = create_job(media_item, preset_name)
+    job.output_dir = output_dir
+
     start_transcode(
         job,
         media_item,
         preset_name,
-        config.transcode_path,
+        output_dir,
     )
 
     return jsonify(

--- a/squishy/blueprints/ui.py
+++ b/squishy/blueprints/ui.py
@@ -113,6 +113,7 @@ def show_detail(show_id):
 def transcode(media_id):
     """Start a transcoding job."""
     preset_name = request.form["preset_name"]
+    output_mode = request.form.get("output_mode", "default")
 
     media_item = get_media(media_id)
     if media_item is None:
@@ -127,8 +128,14 @@ def transcode(media_id):
         else:  # episode
             return redirect(url_for("ui.show_detail", show_id=media_item.show_id))
 
+    if output_mode == "in_place":
+        output_dir = os.path.dirname(media_item.path)
+    else:
+        output_dir = config.transcode_path
+
     job = create_job(media_item, preset_name)
-    start_transcode(job, media_item, preset_name, config.transcode_path)
+    job.output_dir = output_dir
+    start_transcode(job, media_item, preset_name, output_dir)
 
     flash(f"Transcoding job started with preset: {preset_name}")
 

--- a/squishy/effeffmpeg/effeffmpeg.py
+++ b/squishy/effeffmpeg/effeffmpeg.py
@@ -783,7 +783,8 @@ def generate_ffmpeg_command(
     flac_compression: Optional[int] = None,
     overwrite: bool = False,
     quiet: bool = False,
-    progress: bool = False
+    progress: bool = False,
+    subtitle_mode: Optional[str] = None
 ) -> List[str]:
     """
     Generate an FFmpeg command for transcoding video with hardware acceleration awareness.
@@ -806,6 +807,7 @@ def generate_ffmpeg_command(
         flac_compression: FLAC compression level (0-8)
         overwrite: Add -y flag to force overwriting output file
         quiet: Suppress informational output
+        subtitle_mode: Subtitle handling mode ("keep" to copy all subtitle streams, "drop" to exclude them)
 
     Returns:
         A list of strings forming the FFmpeg command
@@ -916,7 +918,11 @@ def generate_ffmpeg_command(
             command += ["-b:a", audio_bitrate]
         if audio_codec == "flac" and flac_compression is not None:
             command += ["-compression_level", str(flac_compression)]
-    
+
+    # Handle subtitle streams
+    if subtitle_mode == "keep":
+        command += ["-c:s", "copy"]
+
     # Add progress reporting option if requested
     # FFmpeg can output machine-readable progress information
     if progress:
@@ -948,7 +954,8 @@ def transcode(
     progress_callback: Optional[Callable[[str, Optional[float]], None]] = None,
     preset_name: Optional[str] = None,
     presets_data: Optional[Dict[str, Dict[str, Any]]] = None,
-    presets_file: Optional[str] = None
+    presets_file: Optional[str] = None,
+    subtitle_mode: Optional[str] = None
 ) -> Union[List[str], subprocess.CompletedProcess, TranscodeProcess]:
     """
     Transcode a video file using FFmpeg with optimal hardware acceleration settings.
@@ -1038,6 +1045,7 @@ def transcode(
     flac_compression_val = flac_compression if flac_compression is not None else preset_config.get('flac_compression')
     allow_fallback_val = allow_fallback or preset_config.get('allow_fallback', False)
     force_software_val = force_software or preset_config.get('force_software', False)
+    subtitle_mode_val = subtitle_mode or preset_config.get('subtitle_mode')
 
     # Get hardware capabilities
     capabilities = None
@@ -1071,7 +1079,8 @@ def transcode(
         flac_compression=flac_compression_val,
         overwrite=overwrite,
         quiet=quiet,
-        progress=(non_blocking or progress_callback is not None)  # Enable progress reporting if we need it
+        progress=(non_blocking or progress_callback is not None),  # Enable progress reporting if we need it
+        subtitle_mode=subtitle_mode_val
     )
 
     # Return the command if dry_run is True

--- a/squishy/models.py
+++ b/squishy/models.py
@@ -138,6 +138,7 @@ class TranscodeJob:
     output_size: Optional[str] = None
     duration: Optional[float] = None
     current_time: Optional[float] = None
+    output_dir: Optional[str] = None  # Output directory (None = use config default)
     process_id: Optional[int] = None  # Store process ID for cancellation
     ffmpeg_command: Optional[str] = None  # Store the FFmpeg command for reference
     ffmpeg_logs: List[str] = field(default_factory=list)  # Store FFmpeg logs

--- a/squishy/templates/admin/add_preset.html
+++ b/squishy/templates/admin/add_preset.html
@@ -221,6 +221,17 @@ document.addEventListener('DOMContentLoaded', function() {
             <p class="help-text">Recommended to leave checked for better reliability.</p>
         </div>
         
+        <div class="form-group">
+            <label>Subtitles</label>
+            <div class="checkbox-group">
+                <label>
+                    <input type="checkbox" id="keep_subtitles" name="keep_subtitles">
+                    Keep subtitle tracks
+                </label>
+            </div>
+            <p class="help-text">If checked, subtitle streams will be copied to the output file.</p>
+        </div>
+
         <div class="form-submit">
             <button type="submit" class="button">Add Preset</button>
         </div>

--- a/squishy/templates/admin/edit_preset.html
+++ b/squishy/templates/admin/edit_preset.html
@@ -215,6 +215,17 @@ document.addEventListener('DOMContentLoaded', function() {
             <p class="help-text">Recommended to leave checked for better reliability.</p>
         </div>
         
+        <div class="form-group">
+            <label>Subtitles</label>
+            <div class="checkbox-group">
+                <label>
+                    <input type="checkbox" id="keep_subtitles" name="keep_subtitles" {% if preset.get('subtitle_mode') == 'keep' %}checked{% endif %}>
+                    Keep subtitle tracks
+                </label>
+            </div>
+            <p class="help-text">If checked, subtitle streams will be copied to the output file.</p>
+        </div>
+
         <div class="form-submit">
             <button type="submit" class="button">Update Preset</button>
         </div>

--- a/squishy/templates/ui/media_detail.html
+++ b/squishy/templates/ui/media_detail.html
@@ -107,7 +107,8 @@
                         {% endfor %}
                     </select>
                 </div>
-                <button type="submit">Squish</button>
+                <button type="submit" name="output_mode" value="default">Squish</button>
+                <button type="submit" name="output_mode" value="in_place" class="secondary">Squish in place</button>
             </form>
         </div>
     </div>

--- a/squishy/templates/ui/show_detail.html
+++ b/squishy/templates/ui/show_detail.html
@@ -171,7 +171,8 @@
                 </div>
 
                 <div class="form-submit">
-                    <button type="submit" class="squish-submit-btn">Squish</button>
+                    <button type="submit" name="output_mode" value="default" class="squish-submit-btn">Squish</button>
+                    <button type="submit" name="output_mode" value="in_place" class="squish-submit-btn secondary">Squish in place</button>
                 </div>
             </form>
         </div>

--- a/squishy/transcoder.py
+++ b/squishy/transcoder.py
@@ -163,7 +163,7 @@ def process_job_queue():
                 )
                 continue
 
-            output_dir = config.transcode_path
+            output_dir = job.output_dir or config.transcode_path
 
             # Start the job
             _start_transcode_job(job, media_item, preset_name, output_dir)
@@ -296,10 +296,10 @@ def transcode(
         job.update_status("processing")
         logger.debug(f"Job {job.id} status changed to processing")
 
-        # Always use the configured transcode_path from config
         config = load_config()
-        output_dir = config.transcode_path
-        logger.info(f"Using configured transcode_path: {output_dir}")
+        if not output_dir:
+            output_dir = config.transcode_path
+        logger.info(f"Using output directory: {output_dir}")
 
         # Get the preset from config
         if preset_name not in config.presets:

--- a/squishy/transcoder.py
+++ b/squishy/transcoder.py
@@ -406,9 +406,8 @@ def transcode(
                 output_file=output_path,
                 dry_run=True,
                 overwrite=True,
-                presets_data={
-                    "preset": preset
-                },  # Wrap the preset in a dict as expected by effeffmpeg
+                preset_name="preset",
+                presets_data={"preset": preset},
             )
 
             # Add the command to the logs right away
@@ -492,6 +491,12 @@ def transcode(
                     process.finished = True
                     process.returncode = process.process.returncode
 
+                    # Wait for reader threads to finish consuming output
+                    if hasattr(process, 'stdout_thread'):
+                        process.stdout_thread.join(timeout=5)
+                    if hasattr(process, 'stderr_thread'):
+                        process.stderr_thread.join(timeout=5)
+
                     # Collect any final output
                     stderr = process.get_stderr()
 
@@ -522,7 +527,13 @@ def transcode(
                 logger.error(
                     f"Transcode failed with code {process.returncode}: {stderr}"
                 )
-                raise RuntimeError(f"Transcode failed with code {process.returncode}")
+                # Add stderr to job logs before raising
+                if stderr:
+                    with job._lock:
+                        for line in stderr.splitlines():
+                            if line.strip():
+                                job.ffmpeg_logs.append(f"STDERR: {line}")
+                raise RuntimeError(f"Transcode failed with code {process.returncode}: {stderr}")
 
             # Update job status
             job.update_status("completed")

--- a/squishy/transcoder.py
+++ b/squishy/transcoder.py
@@ -396,6 +396,10 @@ def transcode(
         if hw_accel and hw_accel.lower() == "none":
             preset["force_software"] = True
 
+        # Strip audio_bitrate when audio_codec is "copy" (bitrate is not applicable)
+        if preset.get("audio_codec") == "copy":
+            preset.pop("audio_bitrate", None)
+
         # Run the effeffmpeg transcoding
         logger.info(f"Starting transcode for job {job.id} using effeffmpeg")
 
@@ -618,9 +622,10 @@ def transcode(
         # Update job status with thread safety
         job.update_status("failed")
 
-        # Update error message with thread safety
+        # Update error message and add to logs for UI visibility
         with job._lock:
             job.error_message = str(e)
+            job.ffmpeg_logs.append(f"ERROR: {str(e)}")
 
         # Make sure to capture final error messages in logs
         if hasattr(e, "stderr") and e.stderr:


### PR DESCRIPTION
- Subtitle preservation in presets: Added a "Keep subtitle tracks" checkbox to preset create/edit forms. When enabled, subtitle streams are copied to the output file (-c:s copy).                                           
- Squish in place: New "Squish in place" button on media detail pages (movies and episodes) to write the transcoded file in the same directory as the source file, instead of the configured transcode_path.
- FFmpeg error log capture fix: FFmpeg errors were invisible in the UI when a job failed quickly. Fixed by waiting for stderr reader threads to finish before collecting logs, and by appending error messages (including
  validation errors) to job logs.
- Audio validation fix: Presets with audio_codec: "copy" and an audio_bitrate set caused a validation error. The audio_bitrate is now automatically stripped when the audio codec is copy.