### PR TITLE
Streams comparison, multi-track support & UI fixes

### DIFF
--- a/squishy/blueprints/api.py
+++ b/squishy/blueprints/api.py
@@ -478,7 +478,18 @@ def replace_original():
         return jsonify({"success": False, "message": f"Original directory does not exist: {original_dir}"}), 404
 
     try:
-        shutil.move(file_path, original_path)
+        # Remove the original file first to avoid permission issues
+        # when overwriting on network/NAS filesystems.
+        if os.path.exists(original_path):
+            os.remove(original_path)
+        try:
+            shutil.move(file_path, original_path)
+        except OSError:
+            # Cross-filesystem move may fail with EPERM when shutil.copy2
+            # tries to preserve extended attributes (common on Synology/NAS).
+            # Fall back to a simple copy without metadata preservation.
+            shutil.copy(file_path, original_path)
+            os.remove(file_path)
         # Remove the sidecar JSON
         if os.path.exists(sidecar_path):
             os.remove(sidecar_path)

--- a/squishy/blueprints/api.py
+++ b/squishy/blueprints/api.py
@@ -1,13 +1,15 @@
 """API blueprint for Squishy."""
 
 import os
+import json
+import shutil
 import traceback
 
 from flask import Blueprint, jsonify, request
 
 from squishy.config import load_config
 from squishy.scanner import get_all_media, get_media, get_scan_status
-from squishy.transcoder import create_job, get_job, start_transcode
+from squishy.transcoder import create_job, get_job, start_transcode, apply_output_path_mapping
 from squishy.media_info import get_media_info, format_file_size
 
 api_bp = Blueprint("api", __name__)
@@ -430,3 +432,56 @@ def list_files():
         return jsonify({"success": False, "message": "Permission denied"}), 403
     except Exception as e:
         return jsonify({"success": False, "message": str(e)}), 500
+
+
+@api_bp.route("/transcode/replace", methods=["POST"])
+def replace_original():
+    """Replace the original file with the transcoded version."""
+    data = request.json
+    if not data or "filename" not in data:
+        return jsonify({"success": False, "message": "Missing filename"}), 400
+
+    filename = data["filename"]
+    config = load_config()
+    transcode_path = apply_output_path_mapping(config.transcode_path)
+
+    file_path = os.path.join(transcode_path, filename)
+    sidecar_path = file_path + ".json"
+
+    # Security check - file must be within transcode directory
+    real_transcode_path = os.path.realpath(transcode_path)
+    real_file_path = os.path.realpath(file_path)
+    if not real_file_path.startswith(real_transcode_path):
+        return jsonify({"success": False, "message": "Security error: invalid file path"}), 403
+
+    # Check transcoded file exists
+    if not os.path.exists(file_path):
+        return jsonify({"success": False, "message": "Transcoded file not found"}), 404
+
+    # Read sidecar to get original_path
+    if not os.path.exists(sidecar_path):
+        return jsonify({"success": False, "message": "Metadata file not found"}), 404
+
+    try:
+        with open(sidecar_path, "r") as f:
+            metadata = json.load(f)
+    except Exception as e:
+        return jsonify({"success": False, "message": f"Error reading metadata: {str(e)}"}), 500
+
+    original_path = metadata.get("original_path")
+    if not original_path:
+        return jsonify({"success": False, "message": "Original path not found in metadata"}), 400
+
+    # Check original directory exists (file itself may have been moved)
+    original_dir = os.path.dirname(original_path)
+    if not os.path.isdir(original_dir):
+        return jsonify({"success": False, "message": f"Original directory does not exist: {original_dir}"}), 404
+
+    try:
+        shutil.move(file_path, original_path)
+        # Remove the sidecar JSON
+        if os.path.exists(sidecar_path):
+            os.remove(sidecar_path)
+        return jsonify({"success": True, "message": "Original file replaced successfully"})
+    except Exception as e:
+        return jsonify({"success": False, "message": f"Error replacing file: {str(e)}"}), 500

--- a/squishy/completed.py
+++ b/squishy/completed.py
@@ -7,13 +7,13 @@ import logging
 from typing import List, Dict, Any, Tuple
 from datetime import datetime
 
-from squishy.transcoder import apply_output_path_mapping
+from squishy.transcoder import apply_output_path_mapping, build_streams_comparison
 
 def get_completed_transcodes(transcode_path: str) -> List[Dict[str, Any]]:
     """Get all completed transcodes with metadata."""
     # Apply path mappings to transcode_path
     transcode_path = apply_output_path_mapping(transcode_path)
-    
+
     # Find all JSON sidecar files
     sidecar_files = glob.glob(os.path.join(transcode_path, "*.json"))
 
@@ -33,6 +33,23 @@ def get_completed_transcodes(transcode_path: str) -> List[Dict[str, Any]]:
             metadata["file_path"] = media_path
             metadata["file_name"] = os.path.basename(media_path)
             metadata["sidecar_path"] = sidecar_path
+
+            # Retrocompat: build streams_comparison if missing
+            if "streams_comparison" not in metadata:
+                original_path = metadata.get("original_path", "")
+                if original_path and os.path.exists(original_path) and os.path.exists(media_path):
+                    try:
+                        streams_comp = build_streams_comparison(original_path, media_path)
+                        if streams_comp:
+                            metadata["streams_comparison"] = streams_comp
+                            # Persist back to sidecar on disk
+                            with open(sidecar_path, "r") as f:
+                                sidecar_data = json.load(f)
+                            sidecar_data["streams_comparison"] = streams_comp
+                            with open(sidecar_path, "w") as f:
+                                json.dump(sidecar_data, f, indent=2)
+                    except Exception as e:
+                        logging.warning(f"Could not build streams comparison for {media_path}: {e}")
 
             # Parse completed_at date for sorting
             if "completed_at" in metadata:

--- a/squishy/completed.py
+++ b/squishy/completed.py
@@ -9,6 +9,8 @@ from datetime import datetime
 
 from squishy.transcoder import apply_output_path_mapping, build_streams_comparison
 
+logger = logging.getLogger(__name__)
+
 def get_completed_transcodes(transcode_path: str) -> List[Dict[str, Any]]:
     """Get all completed transcodes with metadata."""
     # Apply path mappings to transcode_path
@@ -37,7 +39,14 @@ def get_completed_transcodes(transcode_path: str) -> List[Dict[str, Any]]:
             # Retrocompat: build streams_comparison if missing
             if "streams_comparison" not in metadata:
                 original_path = metadata.get("original_path", "")
-                if original_path and os.path.exists(original_path) and os.path.exists(media_path):
+                logger.debug(f"Retrocompat streams_comparison: original_path={original_path}, media_path={media_path}")
+                if not original_path:
+                    logger.debug(f"Skipping streams_comparison: no original_path in sidecar {sidecar_path}")
+                elif not os.path.exists(original_path):
+                    logger.warning(f"Skipping streams_comparison: original_path does not exist: {original_path}")
+                elif not os.path.exists(media_path):
+                    logger.warning(f"Skipping streams_comparison: media_path does not exist: {media_path}")
+                else:
                     try:
                         streams_comp = build_streams_comparison(original_path, media_path)
                         if streams_comp:
@@ -48,8 +57,11 @@ def get_completed_transcodes(transcode_path: str) -> List[Dict[str, Any]]:
                             sidecar_data["streams_comparison"] = streams_comp
                             with open(sidecar_path, "w") as f:
                                 json.dump(sidecar_data, f, indent=2)
-                    except Exception as e:
-                        logging.warning(f"Could not build streams comparison for {media_path}: {e}")
+                            logger.info(f"Retrocompat: updated sidecar with streams_comparison for {media_path}")
+                        else:
+                            logger.warning(f"build_streams_comparison returned None for source={original_path}, output={media_path}")
+                    except Exception:
+                        logger.exception(f"Could not build streams comparison for {media_path}")
 
             # Parse completed_at date for sorting
             if "completed_at" in metadata:

--- a/squishy/effeffmpeg/effeffmpeg.py
+++ b/squishy/effeffmpeg/effeffmpeg.py
@@ -784,7 +784,8 @@ def generate_ffmpeg_command(
     overwrite: bool = False,
     quiet: bool = False,
     progress: bool = False,
-    subtitle_mode: Optional[str] = None
+    subtitle_mode: Optional[str] = None,
+    source_height: Optional[int] = None
 ) -> List[str]:
     """
     Generate an FFmpeg command for transcoding video with hardware acceleration awareness.
@@ -808,6 +809,9 @@ def generate_ffmpeg_command(
         overwrite: Add -y flag to force overwriting output file
         quiet: Suppress informational output
         subtitle_mode: Subtitle handling mode ("keep" to copy all subtitle streams, "drop" to exclude them)
+        source_height: Height of the source video in pixels. When provided, the scale will be
+            capped to avoid upscaling (FFmpeg cannot upscale). If the target resolution is higher
+            than the source, scaling is skipped entirely.
 
     Returns:
         A list of strings forming the FFmpeg command
@@ -864,6 +868,14 @@ def generate_ffmpeg_command(
     using_hardware = encoder and hwaccel == "vaapi"
     if using_hardware and crf is not None and not quiet:
         print("[!] CRF is only allowed with software encoding. CRF will be ignored when hardware encoding is used.")
+
+    # Cap target resolution to source resolution to prevent upscaling
+    if scale and source_height is not None:
+        _, target_height = parse_resolution(scale)
+        if source_height <= target_height:
+            if not quiet:
+                print(f"[!] Source height ({source_height}p) <= target ({scale}). Skipping scaling to avoid upscaling.")
+            scale = None
 
     filters = []
     command = ["ffmpeg"]
@@ -961,7 +973,8 @@ def transcode(
     preset_name: Optional[str] = None,
     presets_data: Optional[Dict[str, Dict[str, Any]]] = None,
     presets_file: Optional[str] = None,
-    subtitle_mode: Optional[str] = None
+    subtitle_mode: Optional[str] = None,
+    source_height: Optional[int] = None
 ) -> Union[List[str], subprocess.CompletedProcess, TranscodeProcess]:
     """
     Transcode a video file using FFmpeg with optimal hardware acceleration settings.
@@ -1086,7 +1099,8 @@ def transcode(
         overwrite=overwrite,
         quiet=quiet,
         progress=(non_blocking or progress_callback is not None),  # Enable progress reporting if we need it
-        subtitle_mode=subtitle_mode_val
+        subtitle_mode=subtitle_mode_val,
+        source_height=source_height
     )
 
     # Return the command if dry_run is True

--- a/squishy/effeffmpeg/effeffmpeg.py
+++ b/squishy/effeffmpeg/effeffmpeg.py
@@ -904,6 +904,12 @@ def generate_ffmpeg_command(
         else:
             command += ["-crf", "28"]
 
+    # Map all streams explicitly (FFmpeg default only picks one per type)
+    command += ["-map", "0:v"]   # All video streams
+    command += ["-map", "0:a"]   # All audio streams
+    if subtitle_mode == "keep":
+        command += ["-map", "0:s?"]  # All subtitle streams (? = ignore if none)
+
     if audio_codec == "copy":
         command += ["-c:a", "copy"]
     else:
@@ -919,7 +925,7 @@ def generate_ffmpeg_command(
         if audio_codec == "flac" and flac_compression is not None:
             command += ["-compression_level", str(flac_compression)]
 
-    # Handle subtitle streams
+    # Handle subtitle codec
     if subtitle_mode == "keep":
         command += ["-c:s", "copy"]
 

--- a/squishy/static/css/squishy.css
+++ b/squishy/static/css/squishy.css
@@ -2116,6 +2116,68 @@ progress {
   padding: 0;
 }
 
+/* Streams comparison table */
+.streams-comparison {
+  margin-top: 0.5rem;
+}
+
+.streams-comparison table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.75rem;
+}
+
+.streams-comparison th,
+.streams-comparison td {
+  padding: 0.2rem 0.4rem;
+  text-align: left;
+  border-bottom: 1px solid #f0f0f0;
+}
+
+.streams-comparison thead th {
+  font-weight: 600;
+  color: #888;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.streams-comparison .sc-label {
+  font-weight: 600;
+  color: #555;
+  white-space: nowrap;
+  width: 60px;
+}
+
+.streams-comparison .sc-size-output {
+  color: var(--success-color);
+  font-weight: 600;
+}
+
+/* Replace button */
+.replace-button img {
+  filter: none;
+}
+
+.btn-danger {
+  background-color: var(--error-color);
+  color: white;
+  border: none;
+  padding: 0.5rem 1.2rem;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.btn-danger:hover {
+  opacity: 0.9;
+}
+
+.btn-danger:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
 /* Loading spinner */
 .loading-container {
   display: flex;

--- a/squishy/static/img/replace.svg
+++ b/squishy/static/img/replace.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24" fill="none" stroke="#555555" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M17 1l4 4-4 4"/>
+  <path d="M3 11V9a4 4 0 0 1 4-4h14"/>
+  <path d="M7 23l-4-4 4-4"/>
+  <path d="M21 13v2a4 4 0 0 1-4 4H3"/>
+</svg>

--- a/squishy/static/js/completed.js
+++ b/squishy/static/js/completed.js
@@ -1,0 +1,84 @@
+/**
+ * Completed transcodes page logic - Replace functionality
+ */
+document.addEventListener('DOMContentLoaded', function() {
+    const replaceModal = document.getElementById('replaceModal');
+    if (!replaceModal) return;
+
+    const confirmBtn = replaceModal.querySelector('.replace-confirm-btn');
+    const cancelBtn = replaceModal.querySelector('.replace-cancel-btn');
+    const closeBtn = replaceModal.querySelector('.close-modal');
+    let currentFilename = null;
+
+    // Open modal on replace button click
+    document.querySelectorAll('.replace-button').forEach(function(btn) {
+        btn.addEventListener('click', function(e) {
+            e.preventDefault();
+            currentFilename = this.getAttribute('data-filename');
+            replaceModal.style.display = 'flex';
+        });
+    });
+
+    // Close modal
+    function closeModal() {
+        replaceModal.style.display = 'none';
+        currentFilename = null;
+    }
+
+    cancelBtn.addEventListener('click', closeModal);
+    closeBtn.addEventListener('click', closeModal);
+    replaceModal.addEventListener('click', function(e) {
+        if (e.target === replaceModal) closeModal();
+    });
+
+    // Confirm replace
+    confirmBtn.addEventListener('click', function() {
+        if (!currentFilename) return;
+
+        var filenameToReplace = currentFilename;
+        confirmBtn.disabled = true;
+        confirmBtn.textContent = 'Replacing...';
+
+        fetch('/api/transcode/replace', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ filename: filenameToReplace })
+        })
+        .then(function(response) { return response.json(); })
+        .then(function(data) {
+            closeModal();
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'Replace';
+
+            if (data.success) {
+                // Find and remove the card with fade-out animation
+                var card = document.querySelector('.replace-button[data-filename="' + filenameToReplace + '"]');
+                if (card) {
+                    card = card.closest('.transcode-card');
+                    if (card) {
+                        card.style.transition = 'opacity 0.4s, transform 0.4s';
+                        card.style.opacity = '0';
+                        card.style.transform = 'scale(0.95)';
+                        setTimeout(function() {
+                            card.remove();
+                            // Check if grid is now empty
+                            var grid = document.querySelector('.transcode-grid');
+                            if (grid && grid.children.length === 0) {
+                                grid.outerHTML = '<div class="empty-state"><div class="empty-state-mascot"><img src="/static/img/anvil-thinking.png" alt="No completed transcodes"></div><p>No completed transcodes found.</p></div>';
+                            }
+                        }, 400);
+                    }
+                }
+                showNotification(data.message, 'success');
+            } else {
+                showNotification(data.message || 'Failed to replace file', 'error');
+            }
+        })
+        .catch(function(err) {
+            closeModal();
+            confirmBtn.disabled = false;
+            confirmBtn.textContent = 'Replace';
+            showNotification('Error: ' + err.message, 'error');
+        });
+    });
+});

--- a/squishy/static/js/jobs.js
+++ b/squishy/static/js/jobs.js
@@ -206,29 +206,38 @@ function updateJobElement(job) {
     if (openLogStates.has(job.id) && job.ffmpeg_logs && job.ffmpeg_logs.length > 0) {
         const logsContentEl = document.getElementById(`logs-content-${job.id}`);
         if (logsContentEl) {
-            // Check if we should auto-scroll based on whether user is already at bottom
             const wasAtBottom = isScrolledToBottom(logsContentEl);
-            
-            // Get current logs
-            let currentLogs = logsContentEl.textContent || '';
-            if (!currentLogs.includes(job.ffmpeg_logs[job.ffmpeg_logs.length - 1])) {
-                // Append new logs if they're not already there
-                job.ffmpeg_logs.forEach(logLine => {
-                    if (!currentLogs.includes(logLine)) {
-                        currentLogs += (currentLogs ? '\n' : '') + logLine;
-                    }
-                });
-                
-                // Update logs content
-                logsContentEl.textContent = currentLogs;
-                
-                // Auto-scroll if we were already at bottom
+
+            // Get current lines (clear "Loading..." placeholder)
+            let lines = logsContentEl.textContent || '';
+            if (lines === 'Loading...' || lines === 'No logs available') {
+                lines = '';
+            }
+            let lineArray = lines ? lines.split('\n') : [];
+
+            // Use a Set of the last N lines for efficient dedup
+            const recentSet = new Set(lineArray.slice(-100));
+            let hasNew = false;
+            for (const logLine of job.ffmpeg_logs) {
+                if (!recentSet.has(logLine)) {
+                    lineArray.push(logLine);
+                    recentSet.add(logLine);
+                    hasNew = true;
+                }
+            }
+
+            // Cap at 500 lines to prevent memory growth
+            if (lineArray.length > 500) {
+                lineArray = lineArray.slice(-500);
+            }
+
+            if (hasNew) {
+                logsContentEl.textContent = lineArray.join('\n');
                 if (wasAtBottom) {
                     setTimeout(() => scrollToBottom(logsContentEl), 10);
                 }
             }
         } else {
-            // If we can't find the logs content element but logs are open, do a full refresh
             loadJobLogs(job.id);
         }
     } else if (openLogStates.has(job.id) && (!job.ffmpeg_logs || job.ffmpeg_logs.length === 0)) {
@@ -244,14 +253,21 @@ function loadJobLogs(jobId) {
     const wasAtBottom = isScrolledToBottom(logsEl);
 
     fetch(`/api/jobs/${jobId}/logs`)
-        .then(response => response.json())
+        .then(response => {
+            if (!response.ok) throw new Error(`HTTP ${response.status}`);
+            return response.json();
+        })
         .then(data => {
             // Update command
             const commandEl = document.getElementById(`command-${jobId}`);
-            commandEl.textContent = data.ffmpeg_command || 'Command not available';
+            if (commandEl) {
+                commandEl.textContent = data.ffmpeg_command || 'Command not available';
+            }
 
             // Update logs
-            logsEl.textContent = data.ffmpeg_logs.join('\n') || 'No logs available';
+            if (logsEl && data.ffmpeg_logs) {
+                logsEl.textContent = data.ffmpeg_logs.join('\n') || 'No logs available';
+            }
 
             // Auto-scroll to bottom if auto-refresh is enabled or user was already at bottom
             if (shouldAutoScroll || wasAtBottom) {
@@ -260,6 +276,9 @@ function loadJobLogs(jobId) {
         })
         .catch(error => {
             console.error('Error fetching logs:', error);
+            if (logsEl && logsEl.textContent === 'Loading...') {
+                logsEl.textContent = 'Could not load logs';
+            }
         });
 }
 

--- a/squishy/templates/ui/completed.html
+++ b/squishy/templates/ui/completed.html
@@ -16,7 +16,7 @@
                 <picture>
                     <!-- Primary image with error handling: if thumbnail fails, try poster -->
                     {% if transcode.thumbnail_url %}
-                    <img src="{{ transcode.thumbnail_url }}" alt="{{ transcode.title }}" 
+                    <img src="{{ transcode.thumbnail_url }}" alt="{{ transcode.title }}"
                          onerror="this.onerror=null; this.src='{{ transcode.poster_url or '' }}'; if(!this.src) this.parentNode.innerHTML='<div class=\'no-poster\'>No Poster</div>';">
                     {% else %}
                     <img src="{{ transcode.poster_url }}" alt="{{ transcode.title }}"
@@ -48,12 +48,50 @@
                         {{ transcode.title }}
                         {% endif %}
                     </h3>
-                    
+
                     <!-- Moved transcode info here from actions section -->
                     <div class="transcode-info">
                         <span class="file-size">{{ transcode.size_comparison }}</span>
                         <span class="transcode-date">Completed: {{ transcode.completed_at_datetime.strftime('%Y-%m-%d %H:%M') }}</span>
                     </div>
+
+                    <!-- Streams comparison table -->
+                    {% if transcode.streams_comparison %}
+                    {% set sc = transcode.streams_comparison %}
+                    <div class="streams-comparison">
+                        <table>
+                            <thead>
+                                <tr><th></th><th>Source</th><th>Output</th></tr>
+                            </thead>
+                            <tbody>
+                                {% if sc.video %}
+                                <tr>
+                                    <td class="sc-label">Video</td>
+                                    <td>{{ sc.video.source.codec }} {{ sc.video.source.resolution }}</td>
+                                    <td>{{ sc.video.output.codec }} {{ sc.video.output.resolution }}</td>
+                                </tr>
+                                {% endif %}
+                                <tr>
+                                    <td class="sc-label">Audio</td>
+                                    <td>{{ sc.audio.source|length }} track{{ 's' if sc.audio.source|length != 1 }}{% if sc.audio.source %} ({{ sc.audio.source[0].codec }}, {{ sc.audio.source[0].channels }}){% endif %}</td>
+                                    <td>{{ sc.audio.output|length }} track{{ 's' if sc.audio.output|length != 1 }}{% if sc.audio.output %} ({{ sc.audio.output[0].codec }}, {{ sc.audio.output[0].channels }}){% endif %}</td>
+                                </tr>
+                                <tr>
+                                    <td class="sc-label">Subtitles</td>
+                                    <td>{{ sc.subtitle.source|length if sc.subtitle.source else 'None' }}</td>
+                                    <td>{{ sc.subtitle.output|length if sc.subtitle.output else 'None' }}</td>
+                                </tr>
+                                {% if sc.format %}
+                                <tr>
+                                    <td class="sc-label">Size</td>
+                                    <td>{{ sc.format.source.size }}</td>
+                                    <td class="sc-size-output">{{ sc.format.output.size }}</td>
+                                </tr>
+                                {% endif %}
+                            </tbody>
+                        </table>
+                    </div>
+                    {% endif %}
                 </div>
 
                 <div class="transcode-actions">
@@ -62,6 +100,10 @@
                            class="circle-button download-circle-button" data-tooltip="Download">
                             <img src="/static/img/download.svg" alt="Download" width="24" height="24">
                         </a>
+                        <button type="button" class="circle-button replace-button" data-tooltip="Replace original"
+                                data-filename="{{ transcode.file_name }}">
+                            <img src="/static/img/replace.svg" alt="Replace" width="24" height="24">
+                        </button>
                         <form action="{{ url_for('ui.delete_completed_transcode', filename=transcode.file_name) }}" method="post" class="delete-form">
                             <button type="submit" class="circle-button cancel-button" data-tooltip="Delete"
                                     onclick="return confirm('Are you sure you want to delete this transcode? This cannot be undone.')">
@@ -74,6 +116,24 @@
         </div>
         {% endfor %}
     </div>
+
+    <!-- Replace confirmation modal -->
+    <div id="replaceModal" class="modal">
+        <div class="modal-content" style="max-width: 450px;">
+            <span class="close-modal">&times;</span>
+            <div class="modal-header">
+                <h2>Replace original file</h2>
+            </div>
+            <div class="modal-body">
+                <p>This will replace the original file with the transcoded version. <strong>This cannot be undone.</strong></p>
+            </div>
+            <div class="modal-footer">
+                <button class="btn replace-cancel-btn">Cancel</button>
+                <button class="btn btn-danger replace-confirm-btn">Replace</button>
+            </div>
+        </div>
+    </div>
+
     {% else %}
     <div class="empty-state">
         <div class="empty-state-mascot">
@@ -83,4 +143,8 @@
     </div>
     {% endif %}
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script src="{{ url_for('static', filename='js/completed.js') }}"></script>
 {% endblock %}

--- a/squishy/transcoder.py
+++ b/squishy/transcoder.py
@@ -519,6 +519,17 @@ def transcode(
         if preset.get("audio_codec") == "copy":
             preset.pop("audio_bitrate", None)
 
+        # Get source resolution to prevent upscaling
+        source_height = None
+        try:
+            media_info = get_media_info(media_item.path)
+            if media_info.get("video"):
+                source_height = media_info["video"][0].get("height")
+                if source_height:
+                    logger.info(f"Source video height: {source_height}p")
+        except Exception as e:
+            logger.warning(f"Could not determine source resolution: {e}")
+
         # Run the effeffmpeg transcoding
         logger.info(f"Starting transcode for job {job.id} using effeffmpeg")
 
@@ -531,6 +542,7 @@ def transcode(
                 overwrite=True,
                 preset_name="preset",
                 presets_data={"preset": preset},
+                source_height=source_height,
             )
 
             # Add the command to the logs right away
@@ -553,6 +565,7 @@ def transcode(
                 preset_name="preset",  # Use the preset name
                 presets_data={"preset": preset},  # Pass the preset data directly
                 quiet=False,  # Ensure we get verbose output for better logs
+                source_height=source_height,
             )
 
             # Store the process ID for potential cancellation

--- a/squishy/transcoder.py
+++ b/squishy/transcoder.py
@@ -15,6 +15,7 @@ from typing import Dict, Optional, List, Callable, Any
 from squishy.config import load_config
 from squishy.models import TranscodeJob, MediaItem, Episode
 from squishy.scanner import get_media
+from squishy.media_info import get_media_info, format_file_size as mi_format_file_size
 from squishy.effeffmpeg.effeffmpeg import (
     transcode as effeff_transcode,
     detect_capabilities,
@@ -22,6 +23,121 @@ from squishy.effeffmpeg.effeffmpeg import (
 
 # Configure logging
 logger = logging.getLogger(__name__)
+
+
+def _format_channels(channels, channel_layout):
+    """Format audio channels into a human-readable string."""
+    if channel_layout:
+        return channel_layout
+    mapping = {1: "mono", 2: "stereo", 6: "5.1", 8: "7.1"}
+    return mapping.get(channels, f"{channels}ch")
+
+
+def _format_bitrate(bit_rate):
+    """Format bitrate into a human-readable string."""
+    if not bit_rate:
+        return ""
+    try:
+        bps = int(bit_rate)
+    except (ValueError, TypeError):
+        return str(bit_rate)
+    if bps >= 1_000_000:
+        return f"{bps / 1_000_000:.1f} Mbps"
+    elif bps >= 1000:
+        return f"{bps / 1000:.0f} kbps"
+    return f"{bps} bps"
+
+
+def build_streams_comparison(source_path, output_path):
+    """Build a streams comparison dict from source and output media files."""
+    source_info = get_media_info(source_path)
+    output_info = get_media_info(output_path)
+
+    if "error" in source_info or "error" in output_info:
+        logger.warning("Could not build streams comparison: media info error")
+        return None
+
+    comparison = {}
+
+    # Video
+    src_video = source_info.get("video", [])
+    out_video = output_info.get("video", [])
+    if src_video or out_video:
+        sv = src_video[0] if src_video else {}
+        ov = out_video[0] if out_video else {}
+        comparison["video"] = {
+            "source": {
+                "codec": sv.get("codec", ""),
+                "resolution": f"{sv.get('width', '')}x{sv.get('height', '')}" if sv.get("width") else "",
+                "bitrate": _format_bitrate(source_info.get("format", {}).get("bit_rate", "")),
+                "frame_rate": sv.get("frame_rate", 0),
+                "bit_depth": sv.get("bit_depth", ""),
+            },
+            "output": {
+                "codec": ov.get("codec", ""),
+                "resolution": f"{ov.get('width', '')}x{ov.get('height', '')}" if ov.get("width") else "",
+                "bitrate": _format_bitrate(output_info.get("format", {}).get("bit_rate", "")),
+                "frame_rate": ov.get("frame_rate", 0),
+                "bit_depth": ov.get("bit_depth", ""),
+            },
+        }
+
+    # Audio
+    src_audio = source_info.get("audio", [])
+    out_audio = output_info.get("audio", [])
+    comparison["audio"] = {
+        "source": [
+            {
+                "codec": a.get("codec", ""),
+                "channels": _format_channels(a.get("channels", 0), a.get("channel_layout", "")),
+                "language": a.get("language", ""),
+                "bitrate": _format_bitrate(a.get("bit_rate", "")),
+            }
+            for a in src_audio
+        ],
+        "output": [
+            {
+                "codec": a.get("codec", ""),
+                "channels": _format_channels(a.get("channels", 0), a.get("channel_layout", "")),
+                "language": a.get("language", ""),
+                "bitrate": _format_bitrate(a.get("bit_rate", "")),
+            }
+            for a in out_audio
+        ],
+    }
+
+    # Subtitle
+    src_sub = source_info.get("subtitle", [])
+    out_sub = output_info.get("subtitle", [])
+    comparison["subtitle"] = {
+        "source": [
+            {"codec": s.get("codec", ""), "language": s.get("language", "")}
+            for s in src_sub
+        ],
+        "output": [
+            {"codec": s.get("codec", ""), "language": s.get("language", "")}
+            for s in out_sub
+        ],
+    }
+
+    # Format (file-level info)
+    src_fmt = source_info.get("format", {})
+    out_fmt = output_info.get("format", {})
+    comparison["format"] = {
+        "source": {
+            "size": mi_format_file_size(src_fmt.get("size", 0)),
+            "bitrate": _format_bitrate(src_fmt.get("bit_rate", "")),
+            "duration": src_fmt.get("duration", 0),
+        },
+        "output": {
+            "size": mi_format_file_size(out_fmt.get("size", 0)),
+            "bitrate": _format_bitrate(out_fmt.get("bit_rate", "")),
+            "duration": out_fmt.get("duration", 0),
+        },
+    }
+
+    return comparison
+
 
 # In-memory job store
 JOBS: Dict[str, TranscodeJob] = {}
@@ -605,6 +721,14 @@ def transcode(
                 show = get_show(media_item.show_id)
                 if show:
                     metadata["show_title"] = show.title
+
+            # Build streams comparison between source and output
+            try:
+                streams_comp = build_streams_comparison(media_item.path, output_path)
+                if streams_comp:
+                    metadata["streams_comparison"] = streams_comp
+            except Exception as e:
+                logger.warning(f"Could not build streams comparison: {e}")
 
             # Write metadata to sidecar file
             with open(sidecar_path, "w") as f:

--- a/squishy/transcoder.py
+++ b/squishy/transcoder.py
@@ -54,7 +54,10 @@ def build_streams_comparison(source_path, output_path):
     output_info = get_media_info(output_path)
 
     if "error" in source_info or "error" in output_info:
-        logger.warning("Could not build streams comparison: media info error")
+        if "error" in source_info:
+            logger.warning(f"Could not get media info for source '{source_path}': {source_info['error']}")
+        if "error" in output_info:
+            logger.warning(f"Could not get media info for output '{output_path}': {output_info['error']}")
         return None
 
     comparison = {}


### PR DESCRIPTION
 **Summary**                                                   
  - Added streams comparison (video/audio/subtitle/format) and Replace button on the completed transcodes page
  - Fixed FFmpeg only copying 1 audio track and 1 subtitle track by adding explicit -map flags for all streams
  - Added diagnostic logging for retrocompat streams_comparison on existing sidecars
  - Fixed memory leak and perpetual "Loading..." state in the jobs log panel
  - Prevent upscaling by capping target resolution to source resolution    

**Changes :**
  Streams comparison & Replace (acf9c50)
  - New streams comparison table on completed transcodes showing source vs output (codec, resolution, bitrate, channels, etc.)
  - Replace button to swap the source file with the transcoded output

  Retrocompat diagnostic logs (3198432)
  - Detailed logging when build_streams_comparison fails for existing json (missing paths, ffprobe errors, full tracebacks)
  - Specific error messages in build_streams_comparison() showing which file failed and why

  Multi-track audio & subtitle preservation (c3b6ccf)
  - Added -map 0:v, -map 0:a, -map 0:s? flags to FFmpeg command generation
  - All audio and subtitle tracks are now preserved instead of just the first of each type

  Jobs log display fixes (93d57f4)
  - Fixed memory leak: replaced O(n) includes() dedup with a Set-based approach, capped DOM log content at 500 lines
  - Fixed "Loading..." text never being cleared when log data arrives via WebSocket
  - Added error handling in loadJobLogs to show failure state instead of infinite "Loading..."
  
  Prevent upscaling (58130a6)
  - FFmpeg cannot properly upscale video. When a preset with a higher resolution than the source file was selected (e.g. 1080p preset on a 720p file), FFmpeg would still attempt a pointless scale, producing a larger file
  with no quality gain.
  - Before transcoding, the source file resolution is now retrieved via ffprobe. If the target preset height is greater than or equal to the source height, the scaling filter is skipped and the video keeps its original
  resolution.
  - Graceful fallback: if ffprobe fails to determine the source resolution, transcoding proceeds normally without upscale protection.
